### PR TITLE
docs: fix README CI badge and align installation extension list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Atelier SVG
 
-[![CI](https://github.com/smnandre/atelier-svg/actions/workflows/ci.yml/badge.svg)](https://github.com/smnandre/atelier-svg/actions/workflows/ci.yml)
+[![CI](https://github.com/ateliersvg/svg/actions/workflows/ci.yml/badge.svg)](https://github.com/ateliersvg/svg/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![PHP 8.3+](https://img.shields.io/badge/PHP-8.3%2B-777BB4.svg)](https://php.net)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,7 +10,7 @@ description: PHP 8.3+, two standard extensions, one Composer command.
 
 PHP 8.3 or higher. No Node, no build step, no external binaries.
 
-The `ext-dom` and `ext-libxml` extensions are required; both ship with PHP and are enabled by default in all standard distributions.
+The `ext-dom` and `ext-xml` extensions are required; both ship with PHP and are enabled by default in all standard distributions.
 
 ## Install
 


### PR DESCRIPTION
## Summary

- Point the CI badge URL in `README.md` at the canonical `ateliersvg/svg` repo (was pointing at the old `smnandre/atelier-svg` path, so the badge currently 404s on the published README).
- In `docs/installation.md`, replace `ext-libxml` with `ext-xml` in the required-extensions sentence so it matches `composer.json` (`ext-dom`, `ext-xml`).

Two-line diff total. No code changes.

## Test plan

- [x] `composer cs` clean
- [x] `composer sa` clean (PHPStan max, 0 errors)
- [x] `git diff main` scoped to `README.md` and `docs/installation.md` only
- [ ] After merge, confirm the CI badge renders on the GitHub README